### PR TITLE
Rails 5.1 Compatibility

### DIFF
--- a/ddc.gemspec
+++ b/ddc.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler", ">= 1.7"
+  spec.add_development_dependency "rake", ">= 10.0"
+  spec.add_development_dependency "rspec", ">= 3.0"
   spec.add_development_dependency "pry"
-  spec.add_dependency "actionpack", "~> 4.1"
-  spec.add_dependency "activesupport", "~> 4.1"
+  spec.add_dependency "actionpack", ">= 4.1"
+  spec.add_dependency "activesupport", ">= 4.1"
 
 end

--- a/lib/ddc/version.rb
+++ b/lib/ddc/version.rb
@@ -1,3 +1,3 @@
 module Ddc
-  VERSION = "0.1.8"
+  VERSION = "0.1.9"
 end

--- a/spec/controller_builder_spec.rb
+++ b/spec/controller_builder_spec.rb
@@ -31,21 +31,21 @@ describe DDC::ControllerBuilder do
     end
 
     it 'raises if there are no actions defined' do
-      expect(->{subject.build :foo, actions: {}}).to raise_exception
-      expect(->{subject.build :foop, {}}).to raise_exception
+      expect(->{subject.build :foo, actions: {}}).to raise_exception(RuntimeError, "Must specify actions")
+      expect(->{subject.build :foop, {}}).to raise_exception(RuntimeError, "Must specify actions")
     end
 
     it 'raises if an action is missing context' do
       expect(->{subject.build :foo, actions: {foo: {
         context_params: [:current_user, :params],
         service: 'baz_service#qux'
-      }}}).to raise_exception
+      }}}).to raise_exception(RuntimeError, "Must specify a context for each action")
     end
 
     it 'raises if an action is missing service' do
       expect(->{subject.build :foo, actions: {foo: {
         context: 'foo_context_builder#bar',
-      }}}).to raise_exception
+      }}}).to raise_exception(RuntimeError, "Must specify a service for each action")
     end
 
     it 'uses the provided parent class' do


### PR DESCRIPTION
Not much needed to change, I just had to make the gemspec a bit more permissive. This patch also silences a warning that shows up when running specs.